### PR TITLE
docs: add organization-wide overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,51 @@
-# PulseEngine MCP Framework for Rust
+# PulseEngine: AI + WebAssembly Infrastructure (Work in Progress)
 
-**Build production-ready Model Context Protocol servers with confidence**
+**Building the intersection of AI and WebAssembly - from safety-critical runtimes to AI-native applications**
 
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
-[![Documentation](https://docs.rs/pulseengine-mcp-protocol/badge.svg)](https://docs.rs/pulseengine-mcp-protocol)
-[![codecov](https://codecov.io/gh/PulseEngineIO/pulseengine-mcp/branch/main/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/PulseEngineIO/pulseengine-mcp)
-[![CI](https://github.com/PulseEngineIO/pulseengine-mcp/actions/workflows/pr-validation.yml/badge.svg)](https://github.com/PulseEngineIO/pulseengine-mcp/actions/workflows/pr-validation.yml)
 
-This framework provides everything you need to build production-ready MCP servers in Rust. It's been developed and proven through a real-world home automation server with 30+ tools that successfully integrates with MCP Inspector, Claude Desktop, and HTTP clients.
+## About PulseEngine
+
+PulseEngine is developing infrastructure at the intersection of AI and WebAssembly. Our projects range from experimental proposals to battle-tested implementations, all focused on enabling AI systems to safely interact with real-world systems through WebAssembly's security model.
+
+## Our Projects
+
+### 🔧 [wrt](https://github.com/pulseengine/wrt) - WebAssembly Runtime (95% complete)
+A safety-critical WebAssembly runtime supporting both Core WebAssembly and Component Model. Designed for ASIL-B compliance with features like Control Flow Integrity, fuel-based execution limiting, and support for no_std environments. Nearly production-ready for embedded and safety-critical applications.
+
+### 🤖 [mcp](https://github.com/pulseengine/mcp) - Rust MCP Framework (Production-tested)
+This framework provides everything you need to build Model Context Protocol servers in Rust. Extracted from a real-world home automation server with 30+ tools that successfully integrates with MCP Inspector, Claude Desktop, and HTTP clients. The most mature of our projects.
+
+### 🎨 [glsp-mcp](https://github.com/pulseengine/glsp-mcp) - AI-Native Graphical Modeling (MVP)
+World's first AI-native implementation of the Graphical Language Server Protocol using MCP. Enables AI agents to create and manipulate diagrams through natural language. Includes a WebAssembly-based ADAS demo showing how WASM components can simulate automotive systems. Functional MVP demonstrating the concept.
+
+### 🏗️ [rules_wasm_component](https://github.com/pulseengine/rules_wasm_component) - Bazel Build Rules (Active Development)
+Modern Bazel rules for building WebAssembly components with multi-profile support. Features 73% faster builds and 99% less disk usage through symlink optimization. Supports Rust, C/C++, and provides seamless integration with the Component Model toolchain.
+
+### 📐 [wasi-mcp](https://github.com/pulseengine/wasi-mcp) - WASI API Proposal (Early Stage)
+A proposed WebAssembly System Interface API for the Model Context Protocol, targeting WASI Preview3. This early-stage proposal aims to standardize how WebAssembly components can act as MCP servers and clients, leveraging WASI's security model for safe AI integration.
+
+## Our Vision
+
+We're exploring what happens when AI systems can safely interact with real-world systems through WebAssembly's security sandbox. Our work spans:
+
+- **Safety-Critical Systems**: Building infrastructure suitable for automotive, medical, and industrial applications
+- **AI-Native Development**: Creating tools that assume AI agents are first-class participants
+- **Secure Integration**: Using WebAssembly's capability-based security for safe AI-to-system interaction
+- **Universal Portability**: Write once, run anywhere - from embedded devices to cloud servers
+
+## Project Status
+
+- ✅ **Production-Ready**: MCP Rust framework (extracted from working system)
+- 🔄 **Nearly Complete**: WRT WebAssembly runtime (95% done, fixing final issues)
+- 🚧 **Active Development**: Bazel build rules, GLSP-MCP platform
+- 📝 **Early Proposal**: WASI-MCP standardization effort
+
+## The Rest of This README: MCP Framework Details
+
+Below you'll find the original documentation for the MCP framework specifically. For information about our other projects, visit their respective repositories.
+
+---
 
 ## What is MCP?
 


### PR DESCRIPTION
## Summary
- Transform MCP framework README to include comprehensive PulseEngine organization overview
- Add descriptions of all PulseEngine projects with realistic status indicators
- Clarify the unified vision of building AI + WebAssembly infrastructure

## Motivation
The previous README only covered the MCP framework itself, which didn't provide context about PulseEngine's broader mission and interconnected projects. Visitors need to understand that we're building a cohesive ecosystem at the intersection of AI and WebAssembly.

## Changes
- Added organization overview section at the top of README
- Listed all PulseEngine projects with descriptions and maturity levels:
  - wrt (95% complete) - Safety-critical WebAssembly runtime
  - mcp (Production-tested) - Rust MCP framework
  - glsp-mcp (MVP) - AI-native graphical modeling
  - rules_wasm_component (Active Development) - Bazel build rules
  - wasi-mcp (Early Stage) - WASI API proposal
- Added vision statement explaining our focus on secure AI-system interaction
- Marked everything as "Work in Progress" to set realistic expectations
- Preserved all original MCP framework documentation below the overview

## Test plan
- [x] README renders correctly with proper markdown formatting
- [x] All project links point to correct repositories
- [x] Status indicators accurately reflect each project's maturity
- [x] Original MCP framework documentation remains intact