### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -100,17 +100,17 @@ assert_matches = "1.5"
 serde_yaml = "0.9"
 
 # Framework internal dependencies (published versions)
-pulseengine-mcp-protocol = { version = "0.8.0", path = "mcp-protocol" }
-pulseengine-mcp-logging = { version = "0.8.0", path = "mcp-logging" }
-pulseengine-mcp-auth = { version = "0.8.0", path = "mcp-auth" }
-pulseengine-mcp-security = { version = "0.8.0", path = "mcp-security" }
-pulseengine-mcp-monitoring = { version = "0.8.0", path = "mcp-monitoring" }
-pulseengine-mcp-transport = { version = "0.8.0", path = "mcp-transport" }
-pulseengine-mcp-cli = { version = "0.8.0", path = "mcp-cli" }
-pulseengine-mcp-cli-derive = { version = "0.8.0", path = "mcp-cli-derive" }
-pulseengine-mcp-server = { version = "0.8.0", path = "mcp-server" }
-pulseengine-mcp-macros = { version = "0.8.0", path = "mcp-macros" }
-pulseengine-mcp-external-validation = { version = "0.8.0", path = "mcp-external-validation" }
+pulseengine-mcp-protocol = { version = "0.8.1", path = "mcp-protocol" }
+pulseengine-mcp-logging = { version = "0.8.1", path = "mcp-logging" }
+pulseengine-mcp-auth = { version = "0.8.1", path = "mcp-auth" }
+pulseengine-mcp-security = { version = "0.8.1", path = "mcp-security" }
+pulseengine-mcp-monitoring = { version = "0.8.1", path = "mcp-monitoring" }
+pulseengine-mcp-transport = { version = "0.8.1", path = "mcp-transport" }
+pulseengine-mcp-cli = { version = "0.8.1", path = "mcp-cli" }
+pulseengine-mcp-cli-derive = { version = "0.8.1", path = "mcp-cli-derive" }
+pulseengine-mcp-server = { version = "0.8.1", path = "mcp-server" }
+pulseengine-mcp-macros = { version = "0.8.1", path = "mcp-macros" }
+pulseengine-mcp-external-validation = { version = "0.8.1", path = "mcp-external-validation" }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
## Summary
- Bump all workspace packages from v0.8.0 to v0.8.1
- Update framework internal dependency versions

## Changes
- Update `[workspace.package]` version to 0.8.1
- Update all `pulseengine-mcp-*` dependency versions to 0.8.1

## Related
- Packages have been published to crates.io
- Git tag v0.8.1 created
- GitHub release created: https://github.com/pulseengine/mcp/releases/tag/v0.8.1

This PR ensures the main branch reflects the published v0.8.1 version.