### PR TITLE
fix: critical resource delegation bug in mcp_server macro (v0.9.1)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -36,7 +36,8 @@
       "mcp__puppeteer__puppeteer_evaluate",
       "WebFetch(domain:lib.rs)",
       "WebFetch(domain:raw.githubusercontent.com)",
-      "Bash(npx @modelcontextprotocol/inspector:*)"
+      "Bash(npx @modelcontextprotocol/inspector:*)",
+      "Bash(./target/release/timedate-mcp-server:*)"
     ],
     "deny": []
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-auth"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "clap",
  "pulseengine-mcp-cli-derive",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-cli-derive"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-external-validation"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-integration-tests"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-logging"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "hex",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-macros"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-monitoring"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-protocol"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-security"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-server"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-transport"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -101,17 +101,17 @@ assert_matches = "1.5"
 serde_yaml = "0.9"
 
 # Framework internal dependencies (published versions)
-pulseengine-mcp-protocol = { version = "0.9.0", path = "mcp-protocol" }
-pulseengine-mcp-logging = { version = "0.9.0", path = "mcp-logging" }
-pulseengine-mcp-auth = { version = "0.9.0", path = "mcp-auth" }
-pulseengine-mcp-security = { version = "0.9.0", path = "mcp-security" }
-pulseengine-mcp-monitoring = { version = "0.9.0", path = "mcp-monitoring" }
-pulseengine-mcp-transport = { version = "0.9.0", path = "mcp-transport" }
-pulseengine-mcp-cli = { version = "0.9.0", path = "mcp-cli" }
-pulseengine-mcp-cli-derive = { version = "0.9.0", path = "mcp-cli-derive" }
-pulseengine-mcp-server = { version = "0.9.0", path = "mcp-server" }
-pulseengine-mcp-macros = { version = "0.9.0", path = "mcp-macros" }
-pulseengine-mcp-external-validation = { version = "0.9.0", path = "mcp-external-validation" }
+pulseengine-mcp-protocol = { version = "0.9.1", path = "mcp-protocol" }
+pulseengine-mcp-logging = { version = "0.9.1", path = "mcp-logging" }
+pulseengine-mcp-auth = { version = "0.9.1", path = "mcp-auth" }
+pulseengine-mcp-security = { version = "0.9.1", path = "mcp-security" }
+pulseengine-mcp-monitoring = { version = "0.9.1", path = "mcp-monitoring" }
+pulseengine-mcp-transport = { version = "0.9.1", path = "mcp-transport" }
+pulseengine-mcp-cli = { version = "0.9.1", path = "mcp-cli" }
+pulseengine-mcp-cli-derive = { version = "0.9.1", path = "mcp-cli-derive" }
+pulseengine-mcp-server = { version = "0.9.1", path = "mcp-server" }
+pulseengine-mcp-macros = { version = "0.9.1", path = "mcp-macros" }
+pulseengine-mcp-external-validation = { version = "0.9.1", path = "mcp-external-validation" }
 
 [profile.release]
 opt-level = "s"

--- a/mcp-macros/src/mcp_server.rs
+++ b/mcp-macros/src/mcp_server.rs
@@ -218,14 +218,18 @@ fn generate_server_implementation(
                 }
             }
 
-            async fn list_resources(&self, _request: pulseengine_mcp_protocol::PaginatedRequestParam) -> std::result::Result<pulseengine_mcp_protocol::ListResourcesResult, Self::Error> {
-                // Default implementation - no resources
-                Ok(pulseengine_mcp_protocol::ListResourcesResult { resources: vec![], next_cursor: None })
+            async fn list_resources(&self, request: pulseengine_mcp_protocol::PaginatedRequestParam) -> std::result::Result<pulseengine_mcp_protocol::ListResourcesResult, Self::Error> {
+                // Use helper method that safely checks for trait implementation
+                let resources = self.try_get_resources_default();
+                Ok(pulseengine_mcp_protocol::ListResourcesResult { resources, next_cursor: request.cursor })
             }
 
             async fn read_resource(&self, request: pulseengine_mcp_protocol::ReadResourceRequestParam) -> std::result::Result<pulseengine_mcp_protocol::ReadResourceResult, Self::Error> {
-                // Default implementation - no resources
-                Err(#error_type_name::InvalidParams(format!("Unknown resource: {}", request.uri)))
+                // Use helper method that calls resource implementation
+                match self.try_read_resource_default(request.clone()).await {
+                    Ok(result) => Ok(result),
+                    Err(e) => Err(#error_type_name::InvalidParams(e.to_string()))
+                }
             }
 
             async fn list_prompts(&self, _request: pulseengine_mcp_protocol::PaginatedRequestParam) -> std::result::Result<pulseengine_mcp_protocol::ListPromptsResult, Self::Error> {


### PR DESCRIPTION
## Summary
Critical hotfix for resource delegation bug that shipped with v0.9.0

- **CRITICAL**: Fixed `mcp_server` macro to properly delegate resource operations to `McpResourcesProvider` trait
- Resources are now fully functional (were completely broken in v0.9.0)
- Made `McpResourcesProvider` trait always implemented (similar to `McpToolsProvider`)
- Updated helper methods to use trait delegation instead of empty defaults

## Problem
v0.9.0 shipped with a major regression where:
- Resources were advertised in capabilities but completely non-functional  
- `list_resources` and `read_resource` methods returned empty/error responses
- The macro wasn't delegating to trait implementations

## Technical Changes
- **mcp-macros/src/mcp_server.rs**: Updated resource methods to use helper delegation
- **mcp-macros/src/mcp_tool.rs**: Made `McpResourcesProvider` always implemented
- All servers now compile whether they have resources defined or not

## Testing
- ✅ Resources now list correctly in MCP Inspector
- ✅ Non-parameterized resources read successfully  
- ✅ Servers without resources compile and work
- ⚠️ Parameterized resources still use hardcoded values (separate issue)

## Release
This fix has been released as **v0.9.1** with all framework crates published to crates.io.

**Resolves the critical bug reported where resources were completely broken in v0.9.0**