### PR TITLE
fix(macros): flatten struct parameters to remove confusing wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-auth"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "clap",
  "pulseengine-mcp-cli-derive",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-cli-derive"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-external-validation"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-integration-tests"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-logging"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "hex",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-macros"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-monitoring"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-security"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-security-middleware"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "pulseengine-mcp-transport"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -108,18 +108,18 @@ assert_matches = "1.5"
 serde_yaml = "0.9"
 
 # Framework internal dependencies (published versions)
-pulseengine-mcp-protocol = { version = "0.10.1", path = "mcp-protocol" }
-pulseengine-mcp-logging = { version = "0.10.1", path = "mcp-logging" }
-pulseengine-mcp-auth = { version = "0.10.1", path = "mcp-auth" }
-pulseengine-mcp-security = { version = "0.10.1", path = "mcp-security" }
-pulseengine-mcp-security-middleware = { version = "0.10.1", path = "mcp-security-middleware" }
-pulseengine-mcp-monitoring = { version = "0.10.1", path = "mcp-monitoring" }
-pulseengine-mcp-transport = { version = "0.10.1", path = "mcp-transport" }
-pulseengine-mcp-cli = { version = "0.10.1", path = "mcp-cli" }
-pulseengine-mcp-cli-derive = { version = "0.10.1", path = "mcp-cli-derive" }
-pulseengine-mcp-server = { version = "0.10.1", path = "mcp-server" }
-pulseengine-mcp-macros = { version = "0.10.1", path = "mcp-macros" }
-pulseengine-mcp-external-validation = { version = "0.10.1", path = "mcp-external-validation" }
+pulseengine-mcp-protocol = { version = "0.11.0", path = "mcp-protocol" }
+pulseengine-mcp-logging = { version = "0.11.0", path = "mcp-logging" }
+pulseengine-mcp-auth = { version = "0.11.0", path = "mcp-auth" }
+pulseengine-mcp-security = { version = "0.11.0", path = "mcp-security" }
+pulseengine-mcp-security-middleware = { version = "0.11.0", path = "mcp-security-middleware" }
+pulseengine-mcp-monitoring = { version = "0.11.0", path = "mcp-monitoring" }
+pulseengine-mcp-transport = { version = "0.11.0", path = "mcp-transport" }
+pulseengine-mcp-cli = { version = "0.11.0", path = "mcp-cli" }
+pulseengine-mcp-cli-derive = { version = "0.11.0", path = "mcp-cli-derive" }
+pulseengine-mcp-server = { version = "0.11.0", path = "mcp-server" }
+pulseengine-mcp-macros = { version = "0.11.0", path = "mcp-macros" }
+pulseengine-mcp-external-validation = { version = "0.11.0", path = "mcp-external-validation" }
 
 [profile.release]
 opt-level = "s"

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -21,6 +21,12 @@ pub struct HelloWorld;
 #[mcp_tools]
 impl HelloWorld {
     /// Say hello to someone
+    ///
+    /// AI agents send flat arguments: `{"name": "Alice"}`
+    /// NOT nested: `{"params": {"name": "Alice"}}`
+    ///
+    /// The parameter name "params" is just an internal variable -
+    /// AI agents see the struct's fields directly in the schema.
     pub async fn say_hello(&self, params: SayHelloParams) -> anyhow::Result<String> {
         let name = params.name.unwrap_or_else(|| "World".to_string());
         Ok(format!("Hello, {name}!"))

--- a/mcp-security-middleware/Cargo.toml
+++ b/mcp-security-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulseengine-mcp-security-middleware"
-version = "0.10.1"
+version = "0.11.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Problem
Single struct parameters had a mismatch between schema and runtime:
- Schema: `{"properties": {"message": ..., "count": ...}}`
- Runtime expected: `{"params": {"message": ..., "count": ...}}`
- AI agents were forced to use a confusing nested structure

## Solution
Implemented smart parameter detection:
- **Custom structs** → Deserialize from entire args object (flattened)
- **Primitives/std types** → Extract by parameter name

## Changes
- Added `is_primitive_or_std_type()` helper
- Updated `extract_parameters()` for single struct handling
- Updated `generate_method_call_with_params()` with same logic
- Added 3 comprehensive runtime tests
- Updated hello-world example documentation

## Testing
✅ All 180+ tests passing
- `test_struct_parameter_flattening_at_runtime` - validates flat args work, nested fails
- `test_multi_param_still_works` - ensures multi-param unchanged  
- `test_optional_struct_fields_work` - tests optional field handling
- All existing tests continue to pass

## Breaking Change
Single struct parameter handling changed. AI agents now send:
```json
{"name": "Alice", "greeting": "Hi"}
```

Instead of:
```json
{"params": {"name": "Alice", "greeting": "Hi"}}
```

## Version
Bumps to 0.11.0