### PR TITLE
ci: migrate 15 of 20 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       contents: read
       pull-requests: write
@@ -49,6 +49,8 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Free up disk space
+        # Only needed on github-hosted; smithy redirects TMPDIR to a 500G volume.
+        if: runner.environment == 'github-hosted'
         run: |
           # Remove unnecessary tools and files to free up ~10GB
           sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/docker-validation.yml
+++ b/.github/workflows/docker-validation.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build-validation-image:
     name: Build Validation Docker Image
+    # Stays on ubuntu-latest: docker buildx + GHCR push; smithy's podman-docker shim is untested for this.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -68,6 +69,7 @@ jobs:
   validate-in-container:
     name: Run Validation in Container
     needs: build-validation-image
+    # Stays on ubuntu-latest: pulls + runs a container image; smithy podman-docker shim is untested.
     runs-on: ubuntu-latest
     if: success()
 
@@ -102,7 +104,7 @@ jobs:
 
   multi-version-testing:
     name: Multi-Version Protocol Testing
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     strategy:
       matrix:
         protocol_version: ["2024-11-05", "2025-03-26"]

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -33,7 +33,7 @@ jobs:
   # Fast validation for PRs - Ubuntu only
   validate-framework-fast:
     name: Fast Framework Validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 25
     if: github.event_name == 'pull_request'
 
@@ -86,6 +86,7 @@ jobs:
   # Full cross-platform validation for main branch and scheduled runs
   validate-framework:
     name: Full Framework Validation
+    # Stays on ubuntu-latest/macos-latest/windows-latest: matrix spans macOS + Windows; smithy is Linux-only.
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
     if: github.event_name != 'pull_request'
@@ -270,7 +271,7 @@ jobs:
 
   stdio-integration-tests:
     name: Stdio + Inspector Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 20
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
@@ -354,7 +355,7 @@ jobs:
 
   python-sdk-compatibility:
     name: Python SDK Compatibility
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 15
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
 
@@ -392,7 +393,7 @@ jobs:
 
   external-validator-integration:
     name: External Validator Integration
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 20
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
@@ -432,6 +433,8 @@ jobs:
 
   security-validation:
     name: Security Validation
+    # Stays on ubuntu-latest: runs cargo audit; smithy's pinned cargo-audit (0.21.x) rejects CVSS 4.0
+    # advisories (e.g. RUSTSEC-2026-0037). Move once smithy bumps cargo-audit to >=0.22.1.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
@@ -461,7 +464,7 @@ jobs:
 
   benchmark-validation:
     name: Performance Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     timeout-minutes: 25
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     outputs:
       validation: ${{ steps.filter.outputs.validation }}
       core: ${{ steps.filter.outputs.core }}
@@ -40,7 +40,7 @@ jobs:
 
   quick-validation:
     name: Quick PR Validation
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: changes
 
     steps:
@@ -62,6 +62,8 @@ jobs:
           echo "Rustfmt version: $(cargo fmt --version)"
 
       - name: Free up disk space
+        # Only needed on github-hosted; smithy redirects TMPDIR to a 500G volume.
+        if: runner.environment == 'github-hosted'
         run: |
           # Remove unnecessary tools and files to free up ~10GB
           sudo rm -rf /usr/share/dotnet
@@ -142,7 +144,7 @@ jobs:
 
   validation-specific-tests:
     name: Validation Framework Tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: changes
     if: needs.changes.outputs.validation == 'true'
 
@@ -180,7 +182,7 @@ jobs:
 
   compatibility-check:
     name: Compatibility Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: changes
     if: needs.changes.outputs.core == 'true'
 
@@ -205,7 +207,7 @@ jobs:
 
   pr-report:
     name: Generate PR Report
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: [quick-validation, validation-specific-tests, compatibility-check]
     if: always()
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   validate-release:
     name: Validate Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
       - name: Checkout code
@@ -118,6 +118,7 @@ jobs:
 
   cross-platform-validation:
     name: Cross-Platform Release Validation
+    # Stays on ubuntu-latest/macos-latest/windows-latest: matrix spans macOS + Windows; smithy is Linux-only.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/scheduled-validation.yml
+++ b/.github/workflows/scheduled-validation.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   validate-external-servers:
     name: Validate External MCP Servers
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
       - name: Checkout code
@@ -148,7 +148,7 @@ jobs:
 
   update-compatibility-matrix:
     name: Update Compatibility Matrix
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: validate-external-servers
 
     steps:


### PR DESCRIPTION
## Summary

Conservative migration of mcp's CI to the pulseengine self-hosted fleet,
mirroring spar (#201), rivet (#262), kiln (#247), and gale (#35). 15 of
20 jobs move to smithy `rust-cpu` / `light` classes; 5 stay on hosted
because they depend on docker buildx, the podman-docker shim, the macOS
+ Windows matrix, or the upstream `cargo audit` parser fix that smithy
hasn't shipped yet. Each kept-hosted job has an in-place comment naming
the reason.

## Migrated -> smithy

| Class | Jobs |
|---|---|
| `rust-cpu` (12 G) | `coverage`, `multi-version-testing`, `validate-framework-fast`, `stdio-integration-tests`, `python-sdk-compatibility`, `external-validator-integration`, `benchmark-validation`, `validate-release`, `quick-validation`, `validation-specific-tests`, `compatibility-check`, `validate-external-servers` |
| `light` (4 G) | `changes`, `pr-report`, `update-compatibility-matrix` |

`stdio-integration-tests` and `python-sdk-compatibility` need Node/Python
respectively; smithy ships Node LTS via nvm and Python 3.12, so both
work without extra setup.

## Stays on `ubuntu-latest` (in-place reasons in this PR for context)

| Job | Why hosted |
|---|---|
| `build-validation-image` | docker buildx + GHCR push; smithy's podman-docker shim is untested for this |
| `validate-in-container` | pulls + runs the container image built above |
| `validate-framework` | matrix spans `macos-latest` and `windows-latest`; smithy is Linux x86_64 only |
| `security-validation` | runs `cargo audit`; smithy's pinned cargo-audit 0.21.x rejects CVSS 4.0 advisories (RUSTSEC-2026-0037). Move once smithy bumps to >=0.22.1 |
| `cross-platform-validation` | matrix spans `macos-latest` and `windows-latest` |

## Workarounds applied

- `quick-validation` (pr-validation.yml) and `coverage` (code-coverage.yml)
  had a `Free up disk space` step running `sudo rm -rf` on hosted-only
  paths (`/usr/share/dotnet`, `/usr/local/lib/android`, `/opt/ghc`,
  `/opt/hostedtoolcache/CodeQL`). Smithy redirects `TMPDIR` to a 500 G
  volume, so the cleanup is unnecessary and the `sudo` call would fail.
  Gated each with `if: runner.environment == 'github-hosted'` so the
  step is preserved (and still runs) for any future fallback to hosted.

## Expected win

Same as spar / rivet / kiln / gale: queue elimination on the
org-free-tier 20-concurrent cap dominates total wall time. mcp's PR
validation flows have meaningful compile + coverage work that fits
`rust-cpu` cleanly.

## Test plan

- [ ] All 15 migrated jobs land on smithy runners and finish green
- [ ] All 5 hosted jobs remain unchanged
- [ ] No EACCES events in smithy's `journalctl -u smithy-trace-eacces.service`
- [ ] No "no space left on device" on coverage runs

## Rollback

Revert this commit; all 15 jobs flip back to `ubuntu-latest`.