### PR TITLE
docs(readme): scope the org footer to what is actually proven

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ MIT OR Apache-2.0
 
 <div align="center">
 
-<sub>Part of <a href="https://github.com/pulseengine">PulseEngine</a> &mdash; formally verified WebAssembly toolchain for safety-critical systems</sub>
+<sub>Part of <a href="https://github.com/pulseengine">PulseEngine</a> &mdash; a WebAssembly toolchain for safety-critical systems, with formally verified components</sub>
 
 </div>


### PR DESCRIPTION
docs(readme): scope the org footer to what is actually proven

The footer claimed PulseEngine is a "formally verified WebAssembly toolchain".
It is not, flatly: verification is scoped to specific components (ordeal's
Lean-checked LRAT checker, spar's Lean scheduling proofs, gale/relay's
Verus/Rocq/Kani properties, scry's mechanized soundness). mcp itself carries no
formal proofs, so the footer overclaims hardest exactly where it is least
backed.

Rewords to "a WebAssembly toolchain for safety-critical systems, with formally
verified components" — the same scoping pulseengine.eu adopted for the site-wide
description.

Note for the org: this footer is copy-pasted into at least 10 repos (meld,
sigil, spar, temper, rules_verus, rules_wasm_component, timedate-mcp,
template-mcp-server, wasi-mcp and this one). That is the single-source problem
the claim-verification skill names — worth fixing once and referencing, rather
than editing ten times.

Closes #101

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
